### PR TITLE
🔒 Fix potential argument injection vulnerability in firmware filename

### DIFF
--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -10,6 +10,12 @@ BASE_URL="https://micropython.org"
 # --- 1. DETERMINE FIRMWARE FILE ---
 if [ -n "$1" ]; then
     FIRMWARE_FILE="$1"
+
+    # Ensure filename is treated as a path (prevents argument injection)
+    if [[ "$FIRMWARE_FILE" == -* ]]; then
+        FIRMWARE_FILE="./$FIRMWARE_FILE"
+    fi
+
     if [ ! -f "$FIRMWARE_FILE" ]; then
         echo "❌ Error: File '$FIRMWARE_FILE' not found!"
         exit 1
@@ -29,6 +35,11 @@ else
 
     DOWNLOAD_URL="${BASE_URL}${RELATIVE_PATH}"
     FIRMWARE_FILE=$(basename "$RELATIVE_PATH")
+
+    # Ensure filename is treated as a path (prevents argument injection)
+    if [[ "$FIRMWARE_FILE" == -* ]]; then
+        FIRMWARE_FILE="./$FIRMWARE_FILE"
+    fi
 
     echo "---------------------------------------"
     echo "✅ Found latest version: $FIRMWARE_FILE"


### PR DESCRIPTION
*   🎯 **What:** The vulnerability allowed filenames starting with a hyphen (`-`) to be interpreted as command-line flags by `esptool`.
*   ⚠️ **Risk:** An attacker could trick a user into downloading or using a maliciously named file (e.g., `-erase-flash`) which could execute unintended commands or options in `esptool`.
*   🛡️ **Solution:** The script now checks if `FIRMWARE_FILE` starts with a hyphen and prepends `./` to it, ensuring it is treated as a relative file path. This sanitization is applied both for user-provided arguments and auto-downloaded files.

---
*PR created automatically by Jules for task [4090454916099794437](https://jules.google.com/task/4090454916099794437) started by @worksonmymachine-de*