### PR TITLE
🧹 Parameterize Serial Port Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 * Flashes your ESP8266 with esptool. Intended for Wemos D1 minis.
 * You can provide a firmware file, but it can also scrape the latest 2MB+ version from the micropython.org site.
 * Sets up a venv at the current location and installs esptool.
-* Erases and flashes the device at /dev/ttyUSB0.
+* Erases and flashes the device at /dev/ttyUSB0 (configurable via PORT and BAUD environment variables).

--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # --- CONFIGURATION ---
-VENV_DIR="venv"
-PORT="/dev/ttyUSB0"
-BAUD="460800"
+VENV_DIR="${VENV_DIR:-venv}"
+PORT="${PORT:-/dev/ttyUSB0}"
+BAUD="${BAUD:-460800}"
 DOWNLOAD_PAGE="https://micropython.org/download/ESP8266_GENERIC/"
 BASE_URL="https://micropython.org"
 


### PR DESCRIPTION
This change allows users to override the serial port, baud rate, and virtual environment directory using environment variables. This improves flexibility for different hardware setups and development environments.

Verified with a custom test script mocking `esptool`, `python3`, `curl`, and `wget`.

---
*PR created automatically by Jules for task [18009380508329956431](https://jules.google.com/task/18009380508329956431) started by @worksonmymachine-de*