### PR TITLE
Add test for non-existent firmware file

### DIFF
--- a/tests/test_flasher.sh
+++ b/tests/test_flasher.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Test script for esp8266flasher.sh
+
+TEST_NAME="Non-existent firmware file check"
+SCRIPT_TO_TEST="./esp8266flasher.sh"
+NON_EXISTENT_FILE="non_existent_file.bin"
+
+echo "Running test: $TEST_NAME"
+
+# Capture stdout and stderr
+output=$($SCRIPT_TO_TEST "$NON_EXISTENT_FILE" 2>&1)
+exit_code=$?
+
+# Verify exit code
+if [ $exit_code -ne 1 ]; then
+    echo "❌ FAILED: Expected exit code 1, got $exit_code"
+    exit 1
+fi
+
+# Verify error message
+expected_msg="❌ Error: File '$NON_EXISTENT_FILE' not found!"
+if [[ "$output" != *"$expected_msg"* ]]; then
+    echo "❌ FAILED: Expected output to contain '$expected_msg'"
+    echo "Actual output:"
+    echo "$output"
+    exit 1
+fi
+
+echo "✅ PASSED: $TEST_NAME"
+exit 0


### PR DESCRIPTION
Added a test case in tests/test_flasher.sh to verify that esp8266flasher.sh correctly handles non-existent firmware files by exiting with code 1 and printing an error message.

---
*PR created automatically by Jules for task [11449678158572388219](https://jules.google.com/task/11449678158572388219) started by @worksonmymachine-de*