### PR TITLE
Use `read -r` for Input in `esp8266flasher.sh`

### DIFF
--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -35,7 +35,7 @@ else
     echo "---------------------------------------"
 
     # --- USER CONFIRMATION ---
-    read -p "❓ Download this firmware and flash it? (y/n): " confirm
+    read -r -p "❓ Download this firmware and flash it? (y/n): " confirm
     if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
         echo "🚫 Operation cancelled by user."
         exit 0


### PR DESCRIPTION
Use `read -r` to treat backslashes literally in user input.

---
*PR created automatically by Jules for task [1694859392242803964](https://jules.google.com/task/1694859392242803964) started by @worksonmymachine-de*