### PR TITLE
🧹 Refactor: Extract sanitize_firmware_file helper

### DIFF
--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -9,6 +9,13 @@ BASE_URL="https://micropython.org"
 
 # --- FUNCTIONS ---
 
+# Ensures the firmware file is treated as a path to prevent argument injection.
+sanitize_firmware_file() {
+    if [[ "$FIRMWARE_FILE" == -* ]]; then
+        FIRMWARE_FILE="./$FIRMWARE_FILE"
+    fi
+}
+
 # Determines the firmware file to use.
 # If an argument is provided, checks if it exists.
 # If not, scrapes the download page and prompts to download the latest version.
@@ -18,11 +25,7 @@ get_firmware_file() {
 
     if [ -n "$firmware_arg" ]; then
         FIRMWARE_FILE="$firmware_arg"
-
-        # Ensure filename is treated as a path (prevents argument injection)
-        if [[ "$FIRMWARE_FILE" == -* ]]; then
-            FIRMWARE_FILE="./$FIRMWARE_FILE"
-        fi
+        sanitize_firmware_file
 
         if [ ! -f "$FIRMWARE_FILE" ]; then
             echo "❌ Error: File '$FIRMWARE_FILE' not found!"
@@ -54,11 +57,7 @@ download_firmware() {
 
     local download_url="${BASE_URL}${relative_path}"
     FIRMWARE_FILE=$(basename "$relative_path")
-
-    # Ensure filename is treated as a path (prevents argument injection)
-    if [[ "$FIRMWARE_FILE" == -* ]]; then
-        FIRMWARE_FILE="./$FIRMWARE_FILE"
-    fi
+    sanitize_firmware_file
 
     echo "---------------------------------------"
     echo "✅ Found latest version: $FIRMWARE_FILE"


### PR DESCRIPTION
🎯 **What:** Extracted duplicated filename sanitization logic into a helper function `sanitize_firmware_file`.
💡 **Why:** To improve code maintainability and reduce duplication, ensuring argument injection protection is consistent across the script.
✅ **Verification:** Created and ran a verification script `tests/verify_sanitize.sh` (now deleted) that confirmed the sanitization logic works correctly for files starting with `-`. Also ran existing `tests/test_flasher.sh`.
✨ **Result:** Cleaner code with centralized sanitization logic.

---
*PR created automatically by Jules for task [16297339648177548850](https://jules.google.com/task/16297339648177548850) started by @worksonmymachine-de*