### PR TITLE
🧹 Fix redundant dependency installation in esp8266flasher.sh

### DIFF
--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -109,13 +109,19 @@ setup_venv() {
 # Installs required Python dependencies in the virtual environment.
 install_dependencies() {
     echo "📦 Checking build tools..."
-    pip install --upgrade pip -q
+    if python3 -m pip show esptool > /dev/null 2>&1; then
+        echo "✅ Dependencies already installed."
+        return 0
+    fi
+
+    echo "⬇️  Installing dependencies..."
+    python3 -m pip install --upgrade pip -q
     if [ $? -ne 0 ]; then
         echo "❌ Error: Failed to upgrade pip."
         return 1
     fi
 
-    pip install esptool -q
+    python3 -m pip install esptool -q
     if [ $? -ne 0 ]; then
         echo "❌ Error: Failed to install esptool."
         return 1

--- a/tests/test_deps_check.sh
+++ b/tests/test_deps_check.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+SCRIPT_TO_TEST="./esp8266flasher.sh"
+TEMP_SCRIPT="./test_script_source.sh"
+MOCK_INSTALLED_FILE="mocked_esptool_installed"
+
+# Cleanup function
+cleanup() {
+    rm -f "$TEMP_SCRIPT" "$MOCK_INSTALLED_FILE"
+}
+trap cleanup EXIT
+
+# Copy and strip main execution
+cp "$SCRIPT_TO_TEST" "$TEMP_SCRIPT"
+# Remove the last line which calls main
+sed -i '$d' "$TEMP_SCRIPT"
+
+# Mock pip command
+pip() {
+    echo "pip called with args: $@"
+    if [[ "$1" == "install" ]]; then
+        # Check if esptool is being installed
+        if [[ "$@" == *"esptool"* ]]; then
+            touch "$MOCK_INSTALLED_FILE"
+        fi
+        return 0
+    fi
+    # Handle 'show' for dependency check
+    if [[ "$1" == "show" ]]; then
+         if [ -f "$MOCK_INSTALLED_FILE" ]; then
+             return 0
+         else
+             return 1
+         fi
+    fi
+    return 0
+}
+
+# Mock python3 command
+python3() {
+    if [[ "$1" == "-m" && "$2" == "pip" ]]; then
+        shift 2
+        pip "$@"
+        return $?
+    fi
+    return 0
+}
+
+# Source the script
+source "$TEMP_SCRIPT"
+
+echo "---------------------------------------------------"
+echo "Test 1: Dependencies NOT installed (initial run)"
+echo "---------------------------------------------------"
+rm -f "$MOCK_INSTALLED_FILE"
+
+# Capture output
+output=$(install_dependencies 2>&1)
+echo "$output"
+
+# Check if it tried to install
+if [[ "$output" == *"pip called with args"* && "$output" == *"install"* ]]; then
+    echo "✅ Test 1 Passed: Attempted installation when missing."
+else
+    echo "❌ Test 1 Failed: Did not attempt installation."
+    exit 1
+fi
+
+echo "---------------------------------------------------"
+echo "Test 2: Dependencies ALREADY installed (second run)"
+echo "---------------------------------------------------"
+touch "$MOCK_INSTALLED_FILE"
+
+output=$(install_dependencies 2>&1)
+echo "$output"
+
+if [[ "$output" == *"Dependencies already installed"* ]]; then
+    # Ensure it did NOT call install
+    if [[ "$output" == *"pip called with args"* && "$output" == *"install"* ]]; then
+         echo "❌ Test 2 Failed: Installed despite presence."
+         exit 1
+    else
+         echo "✅ Test 2 Passed: Skipped installation when present."
+    fi
+else
+    echo "❌ Test 2 Failed: Did not detect installed dependencies (or output message missing)."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
🎯 **What:** The `install_dependencies` function in `esp8266flasher.sh` now checks if `esptool` is already installed before attempting to upgrade `pip` and install `esptool`.
💡 **Why:** To improve code health and execution speed by avoiding redundant installation steps, especially in environments with slow or restricted network access.
✅ **Verification:** Added `tests/test_deps_check.sh` which mocks `pip` and verifies that installation is skipped if dependencies are present. Ran existing tests `tests/test_flasher.sh` and confirmed no regressions.
✨ **Result:** The script now efficiently skips dependency installation if already set up.

---
*PR created automatically by Jules for task [10618438663785772405](https://jules.google.com/task/10618438663785772405) started by @worksonmymachine-de*