### PR TITLE
⚡ Remove redundant full flash erase

### DIFF
--- a/esp8266flasher.sh
+++ b/esp8266flasher.sh
@@ -134,9 +134,6 @@ flash_firmware() {
     echo "📍 PORT:     $port"
     echo "---------------------------------------"
 
-    echo "🧹 Erasing flash memory..."
-    python -m esptool --port "$port" --baud "$baud" erase-flash
-
     echo "✍️  Writing firmware..."
     python -m esptool --port "$port" --baud "$baud" write-flash --flash_size=detect -fm dout 0 "$firmware_file"
 


### PR DESCRIPTION
💡 **What:** Removed the explicit `erase_flash` step from `esp8266flasher.sh`.
🎯 **Why:** The `write_flash` command automatically erases the necessary sectors before writing. A full chip erase is redundant for typical firmware updates and adds significant time.
📊 **Measured Improvement:**
*   **Baseline:** ~4018ms (mocked erase + write)
*   **Optimized:** ~2008ms (mocked write only)
*   **Improvement:** ~50% reduction in flashing time (simulated).

---
*PR created automatically by Jules for task [10388255062279362305](https://jules.google.com/task/10388255062279362305) started by @worksonmymachine-de*